### PR TITLE
Lambda Broker: Support for multiple execution permission statements (Issue #3)

### DIFF
--- a/docs/standaloneBrokeredServices/Lambda_Functions.md
+++ b/docs/standaloneBrokeredServices/Lambda_Functions.md
@@ -99,12 +99,15 @@ called **lambda-execution-permission.json. **
 **lambda-execution-permission.json**
 
 ``` js
-{
-    "Action": "lambda:InvokeFunction",
-    "Effect": "Allow",
-    "Principal": "*",
-    "SourceArn": "<arn>"
-}
+[
+    {
+        "Sid": "<OPTIONAL>",
+        "Action": "lambda:InvokeFunction",
+        "Effect": "Allow",
+        "Principal": "*",
+        "SourceArn": "<arn>"
+    }
+]
 ```
 
 <table>

--- a/src/main/java/com/libertymutualgroup/herman/aws/lambda/LambdaPermission.java
+++ b/src/main/java/com/libertymutualgroup/herman/aws/lambda/LambdaPermission.java
@@ -19,6 +19,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class LambdaPermission {
 
+    @JsonProperty("Sid")
+    public String sid;
     @JsonProperty("Action")
     public String action;
     @JsonProperty("EventSourceToken")
@@ -31,6 +33,14 @@ public class LambdaPermission {
     public String qualifier;
     @JsonProperty("SourceArn")
     public String sourceArn;
+
+    public String getSid() {
+        return sid;
+    }
+
+    public void setSid(String sid) {
+        this.sid = sid;
+    }
 
     public String getAction() {
         return action;
@@ -83,7 +93,8 @@ public class LambdaPermission {
     @Override
     public String toString() {
         return "LambdaPermission{" +
-            "action=" + action +
+            "sid=" + sid +
+            ", action='" + action + '\'' +
             ", eventSourceToken='" + eventSourceToken + '\'' +
             ", effect='" + effect + '\'' +
             ", principal='" + principal + '\'' +


### PR DESCRIPTION
Added support (and doc update) for multiple execution permission statements to fix Issue #3. With this, I added a deprecation warning for people using execution permission files that have a single permission object inside so we can remove support for that eventually.