### PR TITLE
Update Spring Framework to latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
     <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
     <aws-sdk.version>1.11.386</aws-sdk.version>
-    <spring.framework.version>5.0.7.RELEASE</spring.framework.version>
+    <spring.framework.version>5.1.1.RELEASE</spring.framework.version>
     <!-- This key is used to keep the consistency between the key in atlassian-plugin.xml
       and the key to generate bundle. -->
     <atlassian.plugin.key>${project.groupId}.${project.artifactId}</atlassian.plugin.key>


### PR DESCRIPTION
Addresses [CVE-2018-11040](url
https://nvd.nist.gov/vuln/detail/CVE-2018-11040) and [CVE-2018-11039](url
https://nvd.nist.gov/vuln/detail/CVE-2018-11039). We likely aren't impacted by these, but I'm not entirely sure how Bamboo interacts with Spring.