### PR TITLE
Adding default log4j configuration

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,0 +1,5 @@
+log4j.rootLogger=debug, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%t %-5p %c{2} - %m%n 

--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -1,4 +1,4 @@
-log4j.rootLogger=debug, stdout
+log4j.rootLogger=info, stdout
 log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout


### PR DESCRIPTION
Using the CLI will trigger a warning from some of the AWS SDK classes reporting that log4j is not properly configured. This PR adds a default configuration to stop those warnings.