### PR TITLE
Send cluster metadata to custom brokers

### DIFF
--- a/src/main/java/com/libertymutualgroup/herman/aws/ecs/EcsPush.java
+++ b/src/main/java/com/libertymutualgroup/herman/aws/ecs/EcsPush.java
@@ -717,7 +717,7 @@ public class EcsPush {
         brokerKinesisStream(definition);
         brokerRds(definition, injectMagic, clusterMetadata, applicationKeyId);
         brokerDynamoDB(definition);
-        brokerCustom(definition, pushContext, lambdaAsyncClient, CustomBrokerPhase.PREPUSH);
+        brokerCustom(definition, pushContext, clusterMetadata, lambdaAsyncClient, CustomBrokerPhase.PREPUSH);
     }
 
 
@@ -822,7 +822,7 @@ public class EcsPush {
         }
     }
 
-    private void brokerServicesPostPush(EcsPushDefinition definition, EcsClusterMetadata meta) {
+    private void brokerServicesPostPush(EcsPushDefinition definition, EcsClusterMetadata clusterMetadata) {
         if (taskProperties.getNewRelic() != null) {
             NewRelicBrokerConfiguration newRelicBrokerConfiguration = new NewRelicBrokerConfiguration()
                 .withBrokerProperties(taskProperties.getNewRelic());
@@ -836,15 +836,15 @@ public class EcsPush {
                 definition.getNewRelic(),
                 definition.getAppName(),
                 definition.getNewRelicApplicationName(),
-                meta.getNewrelicLicenseKey());
+                clusterMetadata.getNewrelicLicenseKey());
         }
 
         if (definition.getBetaAutoscale() != null) {
             AutoscalingBroker asb = new AutoscalingBroker(pushContext);
-            asb.broker(meta, definition);
+            asb.broker(clusterMetadata, definition);
         }
 
-        brokerCustom(definition, pushContext, lambdaAsyncClient, CustomBrokerPhase.POSTPUSH);
+        brokerCustom(definition, pushContext, clusterMetadata, lambdaAsyncClient, CustomBrokerPhase.POSTPUSH);
     }
 
     private void logInvocationInCloudWatch(EcsPushDefinition definition) {
@@ -896,6 +896,7 @@ public class EcsPush {
     private void brokerCustom(
         EcsPushDefinition definition,
         EcsPushContext pushContext,
+        EcsClusterMetadata clusterMetadata,
         AWSLambdaAsync lambdaAsyncClient,
         CustomBrokerPhase phase
     ) {
@@ -908,6 +909,7 @@ public class EcsPush {
                         entry.getValue(),
                         pushContext,
                         definition,
+                        clusterMetadata,
                         config,
                         lambdaAsyncClient
                     );

--- a/src/main/java/com/libertymutualgroup/herman/aws/ecs/broker/custom/CustomBroker.java
+++ b/src/main/java/com/libertymutualgroup/herman/aws/ecs/broker/custom/CustomBroker.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.libertymutualgroup.herman.aws.ecs.EcsPushContext;
 import com.libertymutualgroup.herman.aws.ecs.EcsPushDefinition;
 import com.libertymutualgroup.herman.aws.ecs.broker.custom.CustomBrokerResponse.Status;
+import com.libertymutualgroup.herman.aws.ecs.cluster.EcsClusterMetadata;
 import com.libertymutualgroup.herman.logging.HermanLogger;
 
 import java.io.IOException;
@@ -26,6 +27,7 @@ public class CustomBroker {
     private String name;
     private Object definition;
     private EcsPushDefinition pushDefinition;
+    private EcsClusterMetadata clusterMetadata;
     private CustomBrokerConfiguration configuration;
     private AWSLambdaAsync lambdaClient;
     private HermanLogger logger;
@@ -35,12 +37,14 @@ public class CustomBroker {
         Object definition,
         EcsPushContext pushContext,
         EcsPushDefinition pushDefinition,
+        EcsClusterMetadata clusterMetadata,
         CustomBrokerConfiguration configuration,
         AWSLambdaAsync lambdaClient
     ){
         this.name = name;
         this.definition = definition;
         this.pushDefinition = pushDefinition;
+        this.clusterMetadata = clusterMetadata;
         this.logger = pushContext.getLogger();
         this.configuration = configuration;
         this.lambdaClient = lambdaClient;
@@ -56,7 +60,7 @@ public class CustomBroker {
         }
 
         overlay(brokerDefinition, mapper.valueToTree(definition));
-        CustomBrokerPayload payload = new CustomBrokerPayload(pushDefinition, brokerDefinition);
+        CustomBrokerPayload payload = new CustomBrokerPayload(pushDefinition, clusterMetadata, brokerDefinition);
 
         try{
             InvokeRequest request = new InvokeRequest()

--- a/src/main/java/com/libertymutualgroup/herman/aws/ecs/broker/custom/CustomBrokerPayload.java
+++ b/src/main/java/com/libertymutualgroup/herman/aws/ecs/broker/custom/CustomBrokerPayload.java
@@ -2,13 +2,16 @@ package com.libertymutualgroup.herman.aws.ecs.broker.custom;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.libertymutualgroup.herman.aws.ecs.EcsPushDefinition;
+import com.libertymutualgroup.herman.aws.ecs.cluster.EcsClusterMetadata;
 
 public class CustomBrokerPayload {
     private EcsPushDefinition pushDefinition;
+    private EcsClusterMetadata clusterMetadata;
     private JsonNode brokerDefinition;
 
-    public CustomBrokerPayload(EcsPushDefinition pushDefinition, JsonNode brokerDefinition) {
+    public CustomBrokerPayload(EcsPushDefinition pushDefinition, EcsClusterMetadata clusterMetadata, JsonNode brokerDefinition) {
         this.pushDefinition = pushDefinition;
+        this.clusterMetadata = clusterMetadata;
         this.brokerDefinition = brokerDefinition;
     }
 

--- a/src/test/java/com/libertymutualgroup/herman/aws/ecs/broker/custom/CustomBrokerTest.java
+++ b/src/test/java/com/libertymutualgroup/herman/aws/ecs/broker/custom/CustomBrokerTest.java
@@ -11,6 +11,7 @@ import com.libertymutualgroup.herman.aws.ecs.EcsPushContext;
 import com.libertymutualgroup.herman.aws.ecs.EcsPushDefinition;
 import com.libertymutualgroup.herman.aws.ecs.PropertyHandler;
 import com.libertymutualgroup.herman.aws.ecs.broker.custom.CustomBrokerResponse.Status;
+import com.libertymutualgroup.herman.aws.ecs.cluster.EcsClusterMetadata;
 import com.libertymutualgroup.herman.logging.HermanLogger;
 import com.libertymutualgroup.herman.logging.SysoutLogger;
 import com.libertymutualgroup.herman.task.ecs.ECSPushTaskProperties;
@@ -40,6 +41,7 @@ public class CustomBrokerTest {
     private PropertyHandler propertyHandler;
     private HermanLogger logger = new SysoutLogger();
     private EcsPushDefinition pushDefinition;
+    private EcsClusterMetadata clusterMetadata;
     private CustomBrokerConfiguration config;
     private ObjectMapper mapper = new ObjectMapper();
     private Object brokerDefinition;
@@ -51,6 +53,7 @@ public class CustomBrokerTest {
         propertyHandler = new CliPropertyHandler(logger, "test", ".", new HashMap<>());
         propertyHandler.addProperty("env.var", "envvarvalue");
         pushDefinition = loadTemplate("template.yml", propertyHandler);
+        clusterMetadata = new EcsClusterMetadata();
         ECSPushTaskProperties ecsPushTaskProperties = loadTaskProperties("properties.yml", propertyHandler);
         config = ecsPushTaskProperties.getCustomBrokers().get(brokerName);
         brokerDefinition = pushDefinition.getCustomBrokers().get(brokerName);
@@ -78,6 +81,7 @@ public class CustomBrokerTest {
             brokerDefinition,
             pushContext,
             pushDefinition,
+            clusterMetadata,
             config,
             lambdaClient
         );


### PR DESCRIPTION
Sending cluster metadata to custom brokers. Example use case: RDS broker that needs security group information from the cluster.