### PR TITLE
80 retry exponential backoff

### DIFF
--- a/src/main/java/com/libertymutualgroup/herman/aws/credentials/BambooCredentialsHandler.java
+++ b/src/main/java/com/libertymutualgroup/herman/aws/credentials/BambooCredentialsHandler.java
@@ -19,6 +19,7 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.auth.InstanceProfileCredentialsProvider;
+import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.atlassian.bamboo.task.CommonTaskContext;
 import com.atlassian.bamboo.variable.VariableContext;
 import com.atlassian.bamboo.variable.VariableDefinitionContext;
@@ -59,7 +60,9 @@ public class BambooCredentialsHandler extends CredentialsHandler {
     }
 
     public static ClientConfiguration getConfiguration() {
-        return new ClientConfiguration().withMaxErrorRetry(10);
+        return new ClientConfiguration()
+            .withMaxErrorRetry(10)
+            .withRetryPolicy(PredefinedRetryPolicies.getDefaultRetryPolicyWithCustomMaxRetries(10));
     }
 
     private static String lookupVar(String key, CommonTaskContext context) {

--- a/src/main/java/com/libertymutualgroup/herman/aws/credentials/CredentialsHandler.java
+++ b/src/main/java/com/libertymutualgroup/herman/aws/credentials/CredentialsHandler.java
@@ -18,15 +18,12 @@ package com.libertymutualgroup.herman.aws.credentials;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.retry.PredefinedRetryPolicies;
 
 public class CredentialsHandler {
 
     public AWSCredentials getAWSCredentials() {
         return new DefaultAWSCredentialsProviderChain().getCredentials();
-    }
-
-    public ClientConfiguration getAWSConfiguration() {
-        return new ClientConfiguration().withMaxErrorRetry(10);
     }
 
     // Don't want to change every file in this PR, will refactor later
@@ -35,6 +32,8 @@ public class CredentialsHandler {
     }
 
     public static ClientConfiguration getConfiguration() {
-        return new ClientConfiguration().withMaxErrorRetry(10);
+        return new ClientConfiguration()
+            .withMaxErrorRetry(10)
+            .withRetryPolicy(PredefinedRetryPolicies.getDefaultRetryPolicyWithCustomMaxRetries(10));
     }
 }


### PR DESCRIPTION
We've been seeing intermittent issues where we exceed the AWS rate limit on certain calls to the API via the SDK. The recommendation from AWS was to add a retry of 10 and add a backoff policy. It seems to be working after some testing in the LM environment. 