### PR TITLE
#85 - Allow tags to be applied to ECS clusters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <amps.version>6.2.11</amps.version>
     <plugin.testrunner.version>1.2.3</plugin.testrunner.version>
     <atlassian.spring.scanner.version>1.2.13</atlassian.spring.scanner.version>
-    <aws-sdk.version>1.11.424</aws-sdk.version>
+    <aws-sdk.version>1.11.605</aws-sdk.version>
     <spring.framework.version>5.1.1.RELEASE</spring.framework.version>
     <!-- This key is used to keep the consistency between the key in atlassian-plugin.xml
       and the key to generate bundle. -->

--- a/src/main/java/com/libertymutualgroup/herman/aws/ecs/cluster/EcsClusterPushDefinition.java
+++ b/src/main/java/com/libertymutualgroup/herman/aws/ecs/cluster/EcsClusterPushDefinition.java
@@ -5,6 +5,8 @@
  */
 package com.libertymutualgroup.herman.aws.ecs.cluster;
 
+import com.libertymutualgroup.herman.aws.tags.HermanTag;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -16,6 +18,7 @@ public class EcsClusterPushDefinition {
     private boolean drainingEnabled = true;
     private int maxConcurrentDraining = 3;
     private List<CftParameter> cftParameters = new ArrayList<>();
+    private List<HermanTag> tags;
 
     public String getClusterName() {
         return clusterName;
@@ -71,5 +74,13 @@ public class EcsClusterPushDefinition {
 
     public void setCftParameters(List<CftParameter> cftParameters) {
         this.cftParameters = cftParameters;
+    }
+
+    public List<HermanTag> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<HermanTag> tags) {
+        this.tags = tags;
     }
 }

--- a/src/main/java/com/libertymutualgroup/herman/aws/tags/HermanTag.java
+++ b/src/main/java/com/libertymutualgroup/herman/aws/tags/HermanTag.java
@@ -42,6 +42,14 @@ public class HermanTag {
         return new HermanTag(tag.getKey(), tag.getValue());
     }
 
+    public static HermanTag fromEcsTag(com.amazonaws.services.ecs.model.Tag tag) {
+        return new HermanTag(tag.getKey(), tag.getValue());
+    }
+
+    public static HermanTag fromCftTag(com.amazonaws.services.cloudformation.model.Tag tag) {
+        return new HermanTag(tag.getKey(), tag.getValue());
+    }
+
     public Tag toEc2Tag() {
         return new Tag()
             .withKey(this.key)
@@ -62,6 +70,18 @@ public class HermanTag {
 
     public com.amazonaws.services.dynamodbv2.model.Tag toDynamoTag() {
         return new com.amazonaws.services.dynamodbv2.model.Tag()
+            .withKey(this.key)
+            .withValue(this.value);
+    }
+
+    public com.amazonaws.services.ecs.model.Tag toEcsTag() {
+        return new com.amazonaws.services.ecs.model.Tag()
+            .withKey(this.key)
+            .withValue(this.value);
+    }
+
+    public com.amazonaws.services.cloudformation.model.Tag toCftTag() {
+        return new com.amazonaws.services.cloudformation.model.Tag()
             .withKey(this.key)
             .withValue(this.value);
     }

--- a/src/main/java/com/libertymutualgroup/herman/aws/tags/TagUtil.java
+++ b/src/main/java/com/libertymutualgroup/herman/aws/tags/TagUtil.java
@@ -48,6 +48,14 @@ public class TagUtil {
         return tags.stream().map(HermanTag::toDynamoTag).collect(Collectors.toList());
     }
 
+    public static List<com.amazonaws.services.ecs.model.Tag> hermanToEcsTags(List<HermanTag> tags) {
+        return tags.stream().map(HermanTag::toEcsTag).collect(Collectors.toList());
+    }
+
+    public static List<com.amazonaws.services.cloudformation.model.Tag> hermanToCftTags(List<HermanTag> tags) {
+        return tags.stream().map(HermanTag::toCftTag).collect(Collectors.toList());
+    }
+
     public static Map<String, String> hermanToMap(List<HermanTag> tags) {
         return tags.stream().collect(Collectors.toMap(HermanTag::getKey, HermanTag::getValue));
     }


### PR DESCRIPTION
Added the ability to set tags on cloudformation templates, currently being used to set tags on ECS cluster stacks