### PR TITLE
Adding exception handling for ELB names that exceed 32 character limit

### DIFF
--- a/src/main/java/com/libertymutualgroup/herman/aws/ecs/loadbalancing/EcsLoadBalancerHandler.java
+++ b/src/main/java/com/libertymutualgroup/herman/aws/ecs/loadbalancing/EcsLoadBalancerHandler.java
@@ -74,6 +74,10 @@ public class EcsLoadBalancerHandler {
 
         String appName = definition.getAppName();
 
+        if (appName.length() > 32) {
+            throw new AwsExecException(String.format("Load Balancer name '(%s)' exceeds the 32 maximum character length set by AWS.", appName));
+        }
+
         EcsPortHandler portHandler = new EcsPortHandler();
 
         String protocol = definition.getService().getProtocol();


### PR DESCRIPTION
I've been re-familiarising myself with Herman recently and figured it would be a good idea to make a few contributions. I'd noticed an issue was raised for this and having experienced failed deploys due to longer ELB names, I figured I'd put in some exception handling to cater for this going forward.

My change will throw an exception in the ELB create logic and prevent getting as far as deploying the stack if the ELB name exceeds the 32 character limit set by AWS. I've also added a basic unit test to verify the expected behaviour.