### PR TITLE
Add support in S3 broker for default logging bucket configuration

### DIFF
--- a/src/main/java/com/libertymutualgroup/herman/aws/ecs/broker/s3/S3BrokerProperties.java
+++ b/src/main/java/com/libertymutualgroup/herman/aws/ecs/broker/s3/S3BrokerProperties.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class S3BrokerProperties {
 
     private S3EncryptionOption defaultEncryption;
+    private String defaultLoggingBucket;
 
 
     public S3EncryptionOption getDefaultEncryption() {
@@ -16,6 +17,14 @@ public class S3BrokerProperties {
         this.defaultEncryption = defaultEncryption;
     }
 
+    public String getDefaultLoggingBucket() {
+        return defaultLoggingBucket;
+    }
+
+    public void setDefaultLoggingBucket(String defaultLoggingBucket) {
+        this.defaultLoggingBucket = defaultLoggingBucket;
+    }
+
     public S3BrokerProperties withDefaultEncryption(final S3EncryptionOption defaultEncryption) {
         this.defaultEncryption = defaultEncryption;
         return this;
@@ -24,7 +33,8 @@ public class S3BrokerProperties {
     @Override
     public String toString() {
         return "S3BrokerProperties{" +
-            "defaultEncryption='" + defaultEncryption + '\'' +
+            "defaultEncryption='" + defaultEncryption + "'," +
+            "defaultLoggingBucket='" + defaultLoggingBucket + '\'' +
             '}';
     }
 }

--- a/src/test/resources/sampleTemplates/properties.yml
+++ b/src/test/resources/sampleTemplates/properties.yml
@@ -8,6 +8,7 @@ cftPushVariableBrokerLambda: "herman-cft-push-variable-broker"
 dnsBrokerLambda: "herman-dns-broker"
 s3:
   defaultEncryption: "AES256"
+  defaultLoggingBucket: "my-logging-bucket-1234567890-us-east-1"
 newRelic:
   accountId: 1234567
   nrLambda: "herman-newrelic-broker"


### PR DESCRIPTION
This should accommodate scenarios where users may need access logging configured, but the bucket can be defined at an account-wide level. 