### PR TITLE
Daemon Scheduling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.libertymutualgroup.herman</groupId>
   <artifactId>herman</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
 
   <organization>
     <name>Liberty Mutual</name>
@@ -437,6 +437,18 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+              <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+            </manifest>
+          </archive>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/com/libertymutualgroup/herman/aws/ecs/EcsPushDefinition.java
+++ b/src/main/java/com/libertymutualgroup/herman/aws/ecs/EcsPushDefinition.java
@@ -16,7 +16,6 @@
 package com.libertymutualgroup.herman.aws.ecs;
 
 import com.amazonaws.services.ecs.model.ContainerDefinition;
-import com.amazonaws.services.ecs.model.KeyValuePair;
 import com.amazonaws.services.ecs.model.PlacementStrategy;
 import com.amazonaws.services.ecs.model.TaskDefinitionPlacementConstraint;
 import com.amazonaws.services.ecs.model.Ulimit;
@@ -74,18 +73,6 @@ public class EcsPushDefinition implements IamAppDefinition, KmsAppDefinition, Dy
     private List<WafRuleAction> wafRuleActions;
     private Boolean prePushOnly;
     private Map<String, Object> customBrokers;
-
-    public String getNewRelicApplicationName() {
-        String newRelicApplicationName = null;
-        if (this.getContainerDefinitions() != null) {
-            newRelicApplicationName = this.getContainerDefinitions().iterator().next().getEnvironment().stream()
-                .filter(environmentVar -> "NEW_RELIC_APP_NAME".equals(environmentVar.getName()))
-                .findAny()
-                .map(KeyValuePair::getValue)
-                .orElse(null);
-        }
-        return newRelicApplicationName;
-    }
 
     public List<ContainerDefinition> getContainerDefinitions() {
         return containerDefinitions;

--- a/src/main/java/com/libertymutualgroup/herman/aws/ecs/service/EcsService.java
+++ b/src/main/java/com/libertymutualgroup/herman/aws/ecs/service/EcsService.java
@@ -15,12 +15,13 @@
  */
 package com.libertymutualgroup.herman.aws.ecs.service;
 
-import java.util.List;
-
 import com.amazonaws.services.ecs.model.DeploymentConfiguration;
 import com.amazonaws.services.ecs.model.PlacementConstraint;
 import com.amazonaws.services.ecs.model.PlacementStrategy;
+import com.amazonaws.services.ecs.model.SchedulingStrategy;
 import com.amazonaws.services.elasticloadbalancing.model.HealthCheck;
+
+import java.util.List;
 
 public class EcsService {
 
@@ -37,6 +38,7 @@ public class EcsService {
     private Integer healthCheckGracePeriodSeconds = 0;
     private List<PlacementConstraint> placementConstraints;
     private List<PlacementStrategy> placementStrategies;
+    private SchedulingStrategy schedulingStrategy = SchedulingStrategy.REPLICA;
 
     public int getInstanceCount() {
         return instanceCount;
@@ -143,6 +145,14 @@ public class EcsService {
         this.placementStrategies = placementStrategies;
     }
 
+    public SchedulingStrategy getSchedulingStrategy() {
+        return schedulingStrategy;
+    }
+
+    public void setSchedulingStrategy(SchedulingStrategy schedulingStrategy) {
+        this.schedulingStrategy = schedulingStrategy;
+    }
+
     @Override
     public String toString() {
         return "EcsService{" +
@@ -159,6 +169,7 @@ public class EcsService {
             ", healthCheckGracePeriodSeconds=" + healthCheckGracePeriodSeconds +
             ", placementConstraints=" + placementConstraints +
             ", placementStrategies=" + placementStrategies +
+            ", schedulingStrategy=" + schedulingStrategy +
             '}';
     }
 }

--- a/src/main/java/com/libertymutualgroup/herman/task/bamboo/ecs/ECSPushTask.java
+++ b/src/main/java/com/libertymutualgroup/herman/task/bamboo/ecs/ECSPushTask.java
@@ -56,6 +56,7 @@ public class ECSPushTask extends AbstractDeploymentTask {
         final AtlassianBuildLogger buildLogger = new AtlassianBuildLogger(taskContext.getBuildLogger());
         final AWSCredentials sessionCredentials = BambooCredentialsHandler.getCredentials(taskContext);
         final Regions awsRegion = Regions.fromName(taskContext.getConfigurationMap().get("awsRegion"));
+        buildLogger.addLogEntry("Starting Herman (version: " + getClass().getPackage().getImplementationVersion() + ") " + getClass().getName() + " in aws region: " + awsRegion.getName());
         final int timeout = Integer.parseInt(taskContext.getConfigurationMap().getOrDefault("timeout",
             String.valueOf(ECSPushTaskConfigurator.DEFAULT_TIMEOUT)));
         final PropertyHandler handler = PropertyHandlerUtil

--- a/src/main/java/com/libertymutualgroup/herman/task/bamboo/ecs/cluster/ECSClusterPushTask.java
+++ b/src/main/java/com/libertymutualgroup/herman/task/bamboo/ecs/cluster/ECSClusterPushTask.java
@@ -56,6 +56,7 @@ public class ECSClusterPushTask extends AbstractDeploymentTask {
         final AtlassianBuildLogger buildLogger = new AtlassianBuildLogger(taskContext.getBuildLogger());
         final AWSCredentials sessionCredentials = BambooCredentialsHandler.getCredentials(taskContext);
         final Regions awsRegion = Regions.fromName(taskContext.getConfigurationMap().get("awsRegion"));
+        buildLogger.addLogEntry("Starting Herman (version: " + getClass().getPackage().getImplementationVersion() + ") " + getClass().getName() + " in aws region: " + awsRegion.getName());
         final int timeout = Integer.parseInt(taskContext.getConfigurationMap().getOrDefault("timeout",
             String.valueOf(ECSClusterPushTaskConfigurator.DEFAULT_TIMEOUT)));
         final PropertyHandler handler = PropertyHandlerUtil.getTaskContextPropertyHandler(

--- a/src/main/java/com/libertymutualgroup/herman/task/bamboo/s3/S3CreateTask.java
+++ b/src/main/java/com/libertymutualgroup/herman/task/bamboo/s3/S3CreateTask.java
@@ -21,16 +21,14 @@ import com.atlassian.bamboo.deployments.execution.DeploymentTaskContext;
 import com.atlassian.bamboo.task.TaskResult;
 import com.atlassian.bamboo.task.TaskResultBuilder;
 import com.atlassian.bamboo.variable.CustomVariableContext;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.libertymutualgroup.herman.aws.AbstractDeploymentTask;
 import com.libertymutualgroup.herman.aws.credentials.BambooCredentialsHandler;
 import com.libertymutualgroup.herman.aws.ecs.PropertyHandler;
 import com.libertymutualgroup.herman.aws.ecs.broker.s3.BucketMeta;
 import com.libertymutualgroup.herman.aws.ecs.broker.s3.S3Broker;
 import com.libertymutualgroup.herman.aws.ecs.broker.s3.S3CreateContext;
-import com.libertymutualgroup.herman.task.s3.S3CreateTaskProperties;
 import com.libertymutualgroup.herman.logging.AtlassianBuildLogger;
+import com.libertymutualgroup.herman.task.s3.S3CreateTaskProperties;
 import com.libertymutualgroup.herman.util.ConfigurationUtil;
 import com.libertymutualgroup.herman.util.FileUtil;
 import com.libertymutualgroup.herman.util.PropertyHandlerUtil;
@@ -50,6 +48,7 @@ public class S3CreateTask extends AbstractDeploymentTask {
         final AWSCredentials sessionCredentials = BambooCredentialsHandler.getCredentials(taskContext);
         final Regions awsRegion = Regions.fromName(taskContext.getConfigurationMap().getOrDefault("awsRegion",
             String.valueOf(S3CreateTaskConfigurator.DEFAULT_REGION)));
+        buildLogger.addLogEntry("Starting Herman (version: " + getClass().getPackage().getImplementationVersion() + ") " + getClass().getName() + " in aws region: " + awsRegion.getName());
 
         PropertyHandler handler = PropertyHandlerUtil.getTaskContextPropertyHandler(taskContext, sessionCredentials, getCustomVariableContext());
 

--- a/src/main/java/com/libertymutualgroup/herman/task/cft/CftPushTask.java
+++ b/src/main/java/com/libertymutualgroup/herman/task/cft/CftPushTask.java
@@ -50,6 +50,7 @@ public class CftPushTask extends AbstractDeploymentTask {
         final AtlassianBuildLogger buildLogger = new AtlassianBuildLogger(taskContext.getBuildLogger());
         final AWSCredentials sessionCredentials = BambooCredentialsHandler.getCredentials(taskContext);
         final Regions awsRegion = Regions.fromName(taskContext.getConfigurationMap().get("awsRegion"));
+        buildLogger.addLogEntry("Starting Herman (version: " + getClass().getPackage().getImplementationVersion() + ") " + getClass().getName() + " in aws region: " + awsRegion.getName());
         final PropertyHandler handler = PropertyHandlerUtil.getTaskContextPropertyHandler(taskContext, sessionCredentials, getCustomVariableContext());
         final CftPushTaskProperties taskProperties = CftPushPropertyFactory.getTaskProperties(sessionCredentials, buildLogger, awsRegion, handler);
 

--- a/src/main/java/com/libertymutualgroup/herman/task/lambda/LambdaCreateTask.java
+++ b/src/main/java/com/libertymutualgroup/herman/task/lambda/LambdaCreateTask.java
@@ -50,6 +50,7 @@ public class LambdaCreateTask extends AbstractDeploymentTask {
         final AtlassianBuildLogger buildLogger = new AtlassianBuildLogger(taskContext.getBuildLogger());
         final AWSCredentials sessionCredentials = BambooCredentialsHandler.getCredentials(taskContext);
         final Regions region = Regions.fromName(taskContext.getConfigurationMap().get("awsRegion"));
+        buildLogger.addLogEntry("Starting Herman (version: " + getClass().getPackage().getImplementationVersion() + ") " + getClass().getName() + " in aws region: " + region.getName());
         final PropertyHandler handler = PropertyHandlerUtil
             .getTaskContextPropertyHandler(taskContext, sessionCredentials, getCustomVariableContext());
 


### PR DESCRIPTION
This adds Daemon scheduling to resolve #98 as well as a couple of minor cleanup pieces:
* New Relic has been removed since it doesn't make a lot of sense as part of the deployment flow (where it probably fits better as a post-deploy broker)
* The Herman version will be logged at the start of any execution